### PR TITLE
Comma dangle rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = {
     "prefer-destructuring": ["warn", {"object": true, "array": true}],
     "arrow-parens": ["error", "as-needed", { "requireForBlockBody": false }],
     "radix": ["error", "as-needed"],
-    "comma-dangle": ["error", "only-multiline"]
+    "comma-dangle": ["error", "always-multiline"]
   },
   "extends": ["airbnb-base"]
 };


### PR DESCRIPTION
Alterado para `always-multiline`, para ter sempre uma vírgula no final das linhas quando for multiline (https://eslint.org/docs/rules/comma-dangle#rule-details)