### PR TITLE
no-param-reassign props false

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = {
     "import/prefer-default-export" : 0,
     "radix" : [ 2, "as-needed" ],
     "class-methods-use-this" : 0,
-    "no-param-reassign" : 1,
+    "no-param-reassign" : ["error", { "props": false }],
     "no-console": ["warn", { "allow": ["error"] }],
     "no-use-before-define": ["error", { "functions": false, "classes": true }],
     "prefer-destructuring": ["warn", {"object": true, "array": true}],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-contaazul",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Configs Linter ContaAzul",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Baseado na discussão: https://github.com/ContaAzul/ContaAzulFront/pull/3747

Alterada regra do linter para permitir assign apenas de properties de parâmetros, utilizando [props: false](https://eslint.org/docs/rules/no-param-reassign#props), por exemplo:

```js
// Good
items.forEach((item) => {
  item.title = 'title';
});

// Bad
items.forEach((item) => {
  item = 'title';
});
```