### PR TITLE
add blank line before and after functions and multiline expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,11 @@ module.exports = {
     "arrow-parens": ["error", "as-needed", { "requireForBlockBody": false }],
     "radix": ["error", "as-needed"],
     "comma-dangle": ["error", "always-multiline"],
+    "padding-line-between-statements": [
+      "error",
+      { "blankLine": "always", "prev": "function", "next": "function" },
+      { "blankLine": "always", "prev": "multiline-expression", "next": "multiline-expression" },
+    ],
     "vue/singleline-html-element-content-newline": "off",
     "vue/html-closing-bracket-newline": ["error", {
       "multiline": "never",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-contaazul",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Configs Linter ContaAzul",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adicionar uma linha em branco antes e após declarações de funções e expressoes com mais de uma linha. 

https://eslint.org/docs/rules/padding-line-between-statements

Por exemplo:

![image](https://user-images.githubusercontent.com/14933454/76003870-71ec7680-5ee7-11ea-9eb5-f1aa7ef56330.png)

![image](https://user-images.githubusercontent.com/14933454/76003983-93e5f900-5ee7-11ea-98c1-eafdcf2c5b65.png)

![2020-03-05 13 49 52](https://user-images.githubusercontent.com/14933454/76004416-3605e100-5ee8-11ea-9ad5-582ba3bc7e21.gif)
